### PR TITLE
Fix default executor [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   # Rename this job and add more as needed.
   #
   integration-test-1:
-    executor: orb-tools/ubuntu
+    executor: heroku/default
     steps:
       - checkout
       - heroku/install

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,7 +1,7 @@
 description: >
   A highly efficient and cached Ubuntu-based image. Consider using this executor or selecting an image for your language https://hub.docker.com/r/cimg/
 docker:
-  - image: 'cimg:base/<<parameters.tag>>'
+  - image: 'cimg/base:<<parameters.tag>>'
 parameters:
   tag:
     default: stable


### PR DESCRIPTION
Resolves https://github.com/CircleCI-Public/heroku-orb/issues/3 by fixing the incorrect image name used by the orb's default executor.
Include usage of the executor in integration testing.
