### PR TITLE
[semver:minor] Allow CIRCLE_TAG to be used for deployments, fail if no tag or branch.

### DIFF
--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -24,6 +24,10 @@ parameters:
     type: string
     description: Deploy the given branch. The default value is your current branch.
     default: "$CIRCLE_BRANCH"
+  tag:
+    type: string
+    description: Deploy the given tag. The default value is oyur current tag.
+    default: "$CIRCLE_TAG"
   force:
     type: boolean
     description: Whether or not to force the git push (i.e. `git push -f`). Defaults to false.
@@ -42,12 +46,22 @@ steps:
             command: heroku maintenance:on --app << parameters.app-name >>
   - run:
       no_output_timeout: << parameters.no_output_timeout >>
-      name: Deploy branch to Heroku via git push
+      name: Deploy branch or tag to Heroku via git push
       command: |
         if << parameters.force >>;then
           force="-f"
         fi
-        git push $force https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>:master
+
+        heroku_url = "https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git"
+
+        if [ -z "<< parameters.branch >>" ]; then
+          git push $force $heroku_url << parameters.branch >>:master
+        elif [ -z "<< parameters.tag >>" ]; then
+          git push $force $heroku_url << parameters.tag >>^{}:master
+        else
+          echo "No branch or tag found."
+          exit 1
+        fi
   - when:
       condition: << parameters.maintenance-mode >>
       steps:

--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -26,7 +26,7 @@ parameters:
     default: "$CIRCLE_BRANCH"
   tag:
     type: string
-    description: Deploy the given tag. The default value is oyur current tag.
+    description: Deploy the given tag. The default value is your current tag.
     default: "$CIRCLE_TAG"
   force:
     type: boolean

--- a/src/jobs/deploy-via-git.yml
+++ b/src/jobs/deploy-via-git.yml
@@ -1,5 +1,5 @@
 description: >
-  Quickly and easily take the changes to this branch and deploy them to Heroku automatically with this job.
+  Quickly and easily take the changes to this branch or tag and deploy them to Heroku automatically with this job.
 parameters:
   app-name:
     description:


### PR DESCRIPTION
https://github.com/CircleCI-Public/heroku-orb/issues/7

Should address this issue, as well as failing whenever a branch or tag cannot be found. This seems safer than just running on potentially an empty string.

I'm generally unfamiliar with bash scripting and conditionals, so I would appreciate if anyone else can double check my work / syntax.