### PR TITLE
[semver:patch] allow tag deployments by using full path refs

### DIFF
--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -23,7 +23,7 @@ parameters:
   branch:
     type: string
     description: Deploy the given branch. The default value is your current branch.
-    default: "$CIRCLE_BRANCH"
+    default: "refs/heads/$CIRCLE_BRANCH"
   force:
     type: boolean
     description: Whether or not to force the git push (i.e. `git push -f`). Defaults to false.
@@ -47,7 +47,7 @@ steps:
         if << parameters.force >>;then
           force="-f"
         fi
-        git push $force https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>:master
+        git push $force https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>:refs/heads/master
   - when:
       condition: << parameters.maintenance-mode >>
       steps:


### PR DESCRIPTION
This edit is just more verbose about which reference is being pushed and to which remote

> \<refspec\>: If \<dst\> doesn’t start with `refs/` (e.g. `refs/heads/master`)
> we will try to  infer where in `refs/*` on the destination \<repository\> it belongs based on
> the type of \<src\> being pushed and whether \<dst\> is ambiguous.
> **If \<dst\> unambiguously refers to a ref on the \<repository\> remote, then push to that ref.**

Ref: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-push.html

The added benefit of this edit is that we can now deploy both branches and tags based on the definition of the `parameters.branch`

ex:
- `refs/heads/master` will always deploy the master branch
- `$CIRCLE_BRANCH` is the same default behavior as now
- `refs/heads/$CIRCLE_BRANCH` is the same default behavior now (same as the previous version)
- `refs/tags/$CIRCLE_TAG` is a "hacky" way for deploying tags to Heroku

Fixes: https://github.com/CircleCI-Public/heroku-orb/issues/7
Safer than https://github.com/CircleCI-Public/heroku-orb/pull/8

As when a new repo is created on heroku, the command used in
https://github.com/CircleCI-Public/heroku-orb/pull/8 would fail with the following error
```
hint: The <src> part of the refspec is a commit object.
hint: Did you mean to create a new branch by pushing to
hint: 'v2.0.0^{}:refs/heads/master'?
```

Backward compatible but the naming of the variable could be changed in a later release to indicate that it's taking a reference path to deploy on the `refs/heads/main` heroku branch