### PR TITLE
[semver:patch] deploy-via-git command is using the wrong bash test for string existence

### DIFF
--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -54,9 +54,9 @@ steps:
 
         heroku_url="https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git"
 
-        if [ -z "<< parameters.branch >>" ]; then
+        if [ -n "<< parameters.branch >>" ]; then
           git push $force $heroku_url << parameters.branch >>:master
-        elif [ -z "<< parameters.tag >>" ]; then
+        elif [ -n "<< parameters.tag >>" ]; then
           git push $force $heroku_url << parameters.tag >>^{}:master
         else
           echo "No branch or tag found."


### PR DESCRIPTION
The bash `-z` test returns true if the string is empty. The `-n` test returns true if the string is NOT empty. In the current form of the deploy-via-git command, it will always fail because it will either try to use an empty branch or an empty tag.