### PR TITLE
Fix bug when branch name is provided

### DIFF
--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -54,9 +54,9 @@ steps:
 
         heroku_url="https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git"
 
-        if [ -z "<< parameters.branch >>" ]; then
+        if [ -n "<< parameters.branch >>" ]; then
           git push $force $heroku_url << parameters.branch >>:master
-        elif [ -z "<< parameters.tag >>" ]; then
+        elif [ -n "<< parameters.tag >>" ]; then
           git push $force $heroku_url << parameters.tag >>^{}:master
         else
           echo "No branch or tag found."


### PR DESCRIPTION
Current implementation uses wrong string validation option causing an error when a branch name is provided.

![image](https://user-images.githubusercontent.com/6983510/90576290-633b0880-e183-11ea-9156-3d2ecd7df0fc.png)
