### PR TITLE
Issue #18: fix process types parameter [semver:patch]

### DIFF
--- a/src/commands/push-docker-image.yml
+++ b/src/commands/push-docker-image.yml
@@ -36,5 +36,5 @@ steps:
       name: Push Docker image to Heroku
       command: |
         heroku container:push -a <<parameters.app-name>> \
-        <<# parameters.recursive >>--recursive<</ parameters.recursive >>
+        <<# parameters.recursive >>--recursive<</ parameters.recursive >> \
         <<# parameters.process-types>><<parameters.process-types>><</ parameters.process-types>>


### PR DESCRIPTION
Process types were not picked up by the push-docker-image command, due
to a missing back slash. This should fix that.