### PR TITLE
feat: adding a provision to skip heroku deployment [semver: minor]

### DIFF
--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -58,7 +58,7 @@ steps:
 
         heroku_url="https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git"
 
-        if [[ << parameters.skip-deploy >> == "false" ]]; then
+        if [[ "<< parameters.skip-deploy >>" == "false" ]]; then
           if [ -n "<< parameters.branch >>" ]; then
             git push $force $heroku_url << parameters.branch >>:main
           elif [ -n "<< parameters.tag >>" ]; then
@@ -67,7 +67,7 @@ steps:
             echo "No branch or tag found."
             exit 1
           fi
-        elif [[ << parameters.skip-deploy >> == "true" ]]; then
+        elif [[ "<< parameters.skip-deploy >>" == "true" ]]; then
           echo "Deployment to Heroku App will be skipped, as skip-deploy is set to true"
         else
           echo "Deployment to Heroku App will be skipped, as skip-deploy is not set to false"

--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -32,6 +32,10 @@ parameters:
     type: boolean
     description: Whether or not to force the git push (i.e. `git push -f`). Defaults to false.
     default: false
+  skip-deploy:
+    type: boolean
+    description: Whether or not to deploy to heroku (i.e Conditional Deploy). Defaults to false.
+    default: false
   no_output_timeout:
     type: string
     description:
@@ -54,13 +58,19 @@ steps:
 
         heroku_url="https://heroku:$<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git"
 
-        if [ -n "<< parameters.branch >>" ]; then
-          git push $force $heroku_url << parameters.branch >>:main
-        elif [ -n "<< parameters.tag >>" ]; then
-          git push $force $heroku_url << parameters.tag >>^{}:main
+        if [[ << parameters.skip-deploy >> == "false" ]]; then
+          if [ -n "<< parameters.branch >>" ]; then
+            git push $force $heroku_url << parameters.branch >>:main
+          elif [ -n "<< parameters.tag >>" ]; then
+            git push $force $heroku_url << parameters.tag >>^{}:main
+          else
+            echo "No branch or tag found."
+            exit 1
+          fi
+        elif [[ << parameters.skip-deploy >> == "true" ]]; then
+          echo "Deployment to Heroku App will be skipped, as skip-deploy is set to true"
         else
-          echo "No branch or tag found."
-          exit 1
+          echo "Deployment to Heroku App will be skipped, as skip-deploy is not set to false"
         fi
   - when:
       condition: << parameters.maintenance-mode >>

--- a/src/jobs/deploy-via-git.yml
+++ b/src/jobs/deploy-via-git.yml
@@ -44,6 +44,10 @@ parameters:
     type: boolean
     description: Whether or not to force the git push (i.e. `git push -f`). Defaults to false.
     default: false
+  skip-deploy:
+    type: boolean
+    description: Whether or not to deploy to heroku (i.e Conditional Deploy). Defaults to false.
+    default: false
   no_output_timeout:
     type: string
     description:
@@ -62,5 +66,6 @@ steps:
       branch: << parameters.branch >>
       tag: << parameters.tag >>
       force: << parameters.force >>
+      skip-deploy: << parameters.skip-deploy >>
       no_output_timeout: << parameters.no_output_timeout >>
   - steps: << parameters.post-deploy >>


### PR DESCRIPTION
We use heroku-orb in circleci for our heroku deployments and our heroku deployments are triggered when a new semantic version is created, the semantic version can be created from couple of branches. In this case we want to have a control on the heroku deployment on a each environment based on the semantic version branch.

As we do not have a conditional steps allowed in circleci on orbs , adding the provision in heroku orb by adding a new param
skip-deploy

If it is set to true , the heroku-deploy-via-git will not perform any deployment