### PR TITLE
fix spelling for recursive option

### DIFF
--- a/src/scripts/push-docker-image.sh
+++ b/src/scripts/push-docker-image.sh
@@ -3,7 +3,7 @@
 PARAM_HEROKU_API_KEY="${!PARAM_HEROKU_API_KEY}"
 
 if [ "$PARAM_RECURSIVE" == "1" ];then
-  set -- "$@" --resursive
+  set -- "$@" --recursive
 fi
 
 set -x


### PR DESCRIPTION
Small spelling correction for the recursive option when using the push-docker-image.sh