### PR TITLE
fix: add missing $ to deploy via git app_name env

### DIFF
--- a/src/jobs/deploy-via-git.yml
+++ b/src/jobs/deploy-via-git.yml
@@ -5,7 +5,7 @@ parameters:
     description:
       "Add the name of your application to an environment variable with this name."
     type: string
-    default: HEROKU_APP_NAME
+    default: $HEROKU_APP_NAME
   maintenance-mode:
     description:
       Use this to automatically enable maintenance mode before pre-deploy steps and have it disabled after post-deploy steps have been run.


### PR DESCRIPTION
Seems like a small issue was introduced in #42. This should fix #45