### PR TITLE
feat: add resource-class parameter

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -9,3 +9,9 @@ parameters:
       Pick a specific cimg/base tag:
       https://hub.docker.com/r/cimg/base/tags
     type: string
+  resource-class:
+    default: medium
+    description: >
+      Configure the executor resource class
+    type: string
+resource_class: <<parameters.resource-class>>


### PR DESCRIPTION
### Description
This adds a `resource-class` parameter so you can configure the `resource_class` used by the executor.

### Motivation
We use this orb just to deploy to Heroku which requires very few resources; this option will allow us to use a smaller machine and reduce our credit usage.

Related issue: https://github.com/CircleCI-Public/heroku-orb/issues/41