### PR TITLE
fix: default values refers to strings instead of environment variables

### DIFF
--- a/src/commands/create-review.yml
+++ b/src/commands/create-review.yml
@@ -12,11 +12,11 @@ parameters:
   heroku-api-key:
     type: env_var_name
     description: The name of the environment variable containing your Heroku API Key.
-    default: HEROKU_API_KEY
+    default: $HEROKU_API_KEY
   circleci-api-key:
     type: env_var_name
     description: Environment variable containing the Heroku API key
-    default: CIRCLE_TOKEN
+    default: $CIRCLE_TOKEN
 steps:
   - run:
       command: <<include(scripts/create-review.sh)>>

--- a/src/commands/deploy-via-git.yml
+++ b/src/commands/deploy-via-git.yml
@@ -13,7 +13,7 @@ parameters:
   api-key:
     description: The name of the environment variable containing your Heroku API Key.
     type: env_var_name
-    default: HEROKU_API_KEY
+    default: $HEROKU_API_KEY
   branch:
     type: string
     description: Deploy the given branch. The default value is your current branch. Accepts strings which may contain an environment variable.

--- a/src/commands/push-docker-image.yml
+++ b/src/commands/push-docker-image.yml
@@ -17,7 +17,7 @@ parameters:
   api-key:
     description: The name of the environment variable containing your Heroku API Key.
     type: env_var_name
-    default: HEROKU_API_KEY
+    default: $HEROKU_API_KEY
   no_output_timeout:
     type: string
     description:

--- a/src/commands/release-docker-image.yml
+++ b/src/commands/release-docker-image.yml
@@ -13,7 +13,7 @@ parameters:
   api-key:
     description: The name of the environment variable containing your Heroku API Key.
     type: env_var_name
-    default: HEROKU_API_KEY
+    default: $HEROKU_API_KEY
   no_output_timeout:
     type: string
     description:


### PR DESCRIPTION
Default values are missing "$" so instead of referring to the environment variable it will just pass the string. Might also be related to #45 